### PR TITLE
Add ability to connect to database

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,10 +27,12 @@ jar {
 }
 
 dependencies {
+    implementation "com.oracle.ojdbc:ojdbc8:19.3.0.0"
     implementation "io.github.cdimascio:dotenv-kotlin:6.2.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.4.0"
     implementation "com.discord4j:discord4j-core:3.1.1"
     implementation "ch.qos.logback:logback-classic:1.2.3"
+    implementation 'org.postgresql:postgresql:42.2.10'
 
     testImplementation("junit:junit:4.13")
 }

--- a/src/main/kotlin/com/lwise/MeowBot.kt
+++ b/src/main/kotlin/com/lwise/MeowBot.kt
@@ -2,6 +2,9 @@ package com.lwise
 
 import com.lwise.listeners.messages.MeowListener
 import com.lwise.listeners.reactions.AlignmentReactionListener
+import com.lwise.util.DatabaseClient
+import com.lwise.util.TableTransformer
+import com.lwise.util.log
 import com.lwise.util.subscribeToMessages
 import com.lwise.util.subscribeToReactionAdds
 import com.lwise.util.subscribeToReactionRemoves
@@ -17,6 +20,10 @@ fun main() {
         .build()
         .login()
         .block()
+
+    // test the database connection
+    val result = DatabaseClient.query("SELECT * FROM pg_catalog.pg_tables;", TableTransformer())
+    log("MAIN", result.toString())
 
     val messageListeners = listOf(MeowListener())
     val reactionListeners = listOf(AlignmentReactionListener())

--- a/src/main/kotlin/com/lwise/types/Table.kt
+++ b/src/main/kotlin/com/lwise/types/Table.kt
@@ -1,0 +1,5 @@
+package com.lwise.types
+
+data class Table(
+    val name: String
+)

--- a/src/main/kotlin/com/lwise/util/DatabaseClient.kt
+++ b/src/main/kotlin/com/lwise/util/DatabaseClient.kt
@@ -1,0 +1,50 @@
+package com.lwise.util
+
+import io.github.cdimascio.dotenv.dotenv
+import java.lang.Exception
+import java.net.URI
+import java.sql.Connection
+import java.sql.DriverManager
+
+class DatabaseClient {
+    companion object {
+        private fun connect(): Connection {
+            Class.forName("org.postgresql.Driver") // for debugging
+            val dotenv = dotenv {
+                ignoreIfMissing = true
+            }
+            val dbUri = URI(dotenv["DATABASE_URL"])
+            val username = dbUri.userInfo.split(":")[0]
+            val password = dbUri.userInfo.split(":")[1]
+            val dbUrl = "jdbc:postgresql://" + dbUri.host + ":" + dbUri.port + dbUri.path
+            return DriverManager.getConnection(dbUrl, username, password)
+        }
+
+        fun <T> query(sqlQueryString: String, transformer: ResultTransformer<T>): T? {
+            var result: T? = null
+            try {
+                connect().createStatement().apply {
+                    val resultSet = executeQuery(sqlQueryString)
+                    result = transformer.transform(resultSet)
+                    close()
+                }.close()
+            } catch (exception: Exception) {
+                logException(this::class.java.name, "Failed to query database", exception)
+            }
+            return result
+        }
+
+        fun update(sqlQueryString: String): Int {
+            var rowsUpdated: Int = 0
+            try {
+                connect().createStatement().apply {
+                    rowsUpdated = executeUpdate(sqlQueryString)
+                    close()
+                }.close()
+            } catch (exception: Exception) {
+                logException(this::class.java.name, "Failed to update database", exception)
+            }
+            return rowsUpdated
+        }
+    }
+}

--- a/src/main/kotlin/com/lwise/util/LogUtility.kt
+++ b/src/main/kotlin/com/lwise/util/LogUtility.kt
@@ -1,8 +1,14 @@
 package com.lwise.util
 
 import org.slf4j.LoggerFactory
+import java.lang.Exception
 
 fun log(className: String, message: String) {
     val logger = LoggerFactory.getLogger(className)
     logger.debug(message)
+}
+
+fun logException(className: String, message: String, exception: Exception) {
+    val logger = LoggerFactory.getLogger(className)
+    logger.error(className, message, exception)
 }

--- a/src/main/kotlin/com/lwise/util/ResultTransformer.kt
+++ b/src/main/kotlin/com/lwise/util/ResultTransformer.kt
@@ -1,0 +1,7 @@
+package com.lwise.util
+
+import java.sql.ResultSet
+
+interface ResultTransformer<T> {
+    fun transform(resultSet: ResultSet): T
+}

--- a/src/main/kotlin/com/lwise/util/TableTransformer.kt
+++ b/src/main/kotlin/com/lwise/util/TableTransformer.kt
@@ -1,0 +1,11 @@
+package com.lwise.util
+
+import com.lwise.types.Table
+import java.sql.ResultSet
+
+class TableTransformer : ResultTransformer<Table> {
+    override fun transform(resultSet: ResultSet): Table {
+        resultSet.next()
+        return Table(resultSet.getString("tablename"))
+    }
+}


### PR DESCRIPTION
Adds in database connection plugins and logic, with the concept of a data transformer so that most SQL code is actually just hidden in the `DatabaseClient` file.

I wanted to use http://dbunit.sourceforge.net/index.html to test but it seems like you need a real test database set up.


Not sure if the connection code will work on Heroku but I followed the steps so hopefully it does. :/

Resolves #13