### PR TITLE
Add Alignment Opt-In listener

### DIFF
--- a/src/main/kotlin/com/lwise/MeowBot.kt
+++ b/src/main/kotlin/com/lwise/MeowBot.kt
@@ -1,5 +1,6 @@
 package com.lwise
 
+import com.lwise.listeners.messages.AlignmentOptInListener
 import com.lwise.listeners.messages.MeowListener
 import com.lwise.listeners.reactions.AlignmentReactionListener
 import com.lwise.util.DatabaseClient
@@ -25,7 +26,7 @@ fun main() {
     val result = DatabaseClient.query("SELECT * FROM pg_catalog.pg_tables;", TableTransformer())
     log("MAIN", result.toString())
 
-    val messageListeners = listOf(MeowListener())
+    val messageListeners = listOf(MeowListener(), AlignmentOptInListener())
     val reactionListeners = listOf(AlignmentReactionListener())
     client?.apply {
         subscribeToReady()

--- a/src/main/kotlin/com/lwise/alignment/AlignmentDefinitions.kt
+++ b/src/main/kotlin/com/lwise/alignment/AlignmentDefinitions.kt
@@ -2,6 +2,17 @@ package com.lwise.alignment
 
 class AlignmentDefinitions {
     companion object {
-        val EMOJI_NAME_LIST = listOf("lawful", "chaotic", "good", "evil")
+        val EMOJI_NAMES = listOf("lawful", "chaotic", "good", "evil")
+        val ALIGNMENT_ROLES = listOf(
+            "Chaotic Evil",
+            "Chaotic Good",
+            "Chaotic Neutral",
+            "True Neutral",
+            "Lawful Neutral",
+            "Lawful Good",
+            "Lawful Evil",
+            "Neutral Good",
+            "Neutral Evil"
+        )
     }
 }

--- a/src/main/kotlin/com/lwise/listeners/messages/AlignmentOptInListener.kt
+++ b/src/main/kotlin/com/lwise/listeners/messages/AlignmentOptInListener.kt
@@ -1,0 +1,35 @@
+package com.lwise.listeners.messages
+
+import com.lwise.alignment.AlignmentDefinitions.Companion.ALIGNMENT_ROLES
+import com.lwise.types.MessageEvent
+import com.lwise.util.log
+import discord4j.core.`object`.entity.Message
+import reactor.core.publisher.Mono
+
+class AlignmentOptInListener : MessageListener {
+    override val regexString: String = "meow!play alignment"
+
+    override fun isTriggered(content: String): Boolean {
+        return content.equals(regexString, ignoreCase = true)
+    }
+
+    override fun getResponseMessage() = "<:hello:698742819933913139> welcome to the alignment game~!"
+    private fun getFailureResponseMessage() = "it looks like you are already participating in the alignment game <:yespls:698742820273651773>"
+
+    override fun respond(responseVector: MessageEvent): Mono<Message> {
+        val userToOptIn = responseVector.author
+        val userAlignmentRoles = userToOptIn.roles
+            .map { role ->
+                log(this.javaClass.name, role.name)
+                role.name
+            }.filter { roleName ->
+                ALIGNMENT_ROLES.contains(roleName)
+            }.collectList()
+        val filteredRoles = userAlignmentRoles.block()!!
+        return if (!filteredRoles.isNullOrEmpty()) {
+            responseVector.channel.createMessage(getFailureResponseMessage())
+        } else {
+            super.respond(responseVector)
+        }
+    }
+}

--- a/src/main/kotlin/com/lwise/listeners/messages/MessageListener.kt
+++ b/src/main/kotlin/com/lwise/listeners/messages/MessageListener.kt
@@ -1,11 +1,11 @@
 package com.lwise.listeners.messages
 
 import com.lwise.listeners.Listener
+import com.lwise.types.MessageEvent
 import discord4j.core.`object`.entity.Message
-import discord4j.core.`object`.entity.channel.MessageChannel
 import reactor.core.publisher.Mono
 
-interface MessageListener : Listener<MessageChannel> {
+interface MessageListener : Listener<MessageEvent> {
     // use lowercase match
     val regexString: String
 
@@ -14,8 +14,8 @@ interface MessageListener : Listener<MessageChannel> {
         return regex.containsMatchIn(content.toLowerCase())
     }
 
-    override fun respond(responseVector: MessageChannel): Mono<Message> {
-        return responseVector.createMessage(getResponseMessage())
+    override fun respond(responseVector: MessageEvent): Mono<Message> {
+        return responseVector.channel.createMessage(getResponseMessage())
     }
 
     fun getResponseMessage(): String

--- a/src/main/kotlin/com/lwise/listeners/reactions/AlignmentReactionListener.kt
+++ b/src/main/kotlin/com/lwise/listeners/reactions/AlignmentReactionListener.kt
@@ -1,13 +1,13 @@
 package com.lwise.listeners.reactions
 
-import com.lwise.alignment.AlignmentDefinitions.Companion.EMOJI_NAME_LIST
+import com.lwise.alignment.AlignmentDefinitions.Companion.EMOJI_NAMES
 import com.lwise.types.ReactionEvent
 import discord4j.core.`object`.entity.Message
 import reactor.core.publisher.Mono
 
 class AlignmentReactionListener : ReactionListener {
     override fun isTriggered(content: String): Boolean {
-        return EMOJI_NAME_LIST.contains(content)
+        return EMOJI_NAMES.contains(content)
     }
 
     override fun respond(responseVector: ReactionEvent): Mono<Message> {

--- a/src/main/kotlin/com/lwise/types/EventTypes.kt
+++ b/src/main/kotlin/com/lwise/types/EventTypes.kt
@@ -1,9 +1,12 @@
 package com.lwise.types
 
+import discord4j.core.`object`.entity.Guild
+import discord4j.core.`object`.entity.Member
 import discord4j.core.`object`.entity.Message
 import discord4j.core.`object`.entity.User
 import discord4j.core.`object`.entity.channel.MessageChannel
 import discord4j.core.`object`.reaction.ReactionEmoji
+import discord4j.core.event.domain.message.MessageCreateEvent
 import discord4j.core.event.domain.message.ReactionAddEvent
 import discord4j.core.event.domain.message.ReactionRemoveEvent
 
@@ -19,6 +22,13 @@ data class ReactionEvent(
     val reactingUser: User,
     val userReactedTo: User,
     val eventType: ReactionEventType
+)
+
+data class MessageEvent(
+    val message: Message,
+    val guild: Guild,
+    val channel: MessageChannel,
+    val author: Member
 )
 
 fun ReactionAddEvent.toReactionAddEvent(): ReactionEvent {
@@ -42,5 +52,14 @@ fun ReactionRemoveEvent.toReactionRemoveEvent(): ReactionEvent {
         reactingUser = user.block()!!,
         userReactedTo = messageData.author.get(),
         eventType = ReactionEventType.REMOVED
+    )
+}
+
+fun MessageCreateEvent.toMessageEvent(): MessageEvent {
+    return MessageEvent(
+        message = message,
+        guild = guild.block()!!,
+        channel = message.channel.block()!!,
+        author = member.get()
     )
 }

--- a/src/main/kotlin/com/lwise/util/GatewayDiscordClientExtensions.kt
+++ b/src/main/kotlin/com/lwise/util/GatewayDiscordClientExtensions.kt
@@ -2,10 +2,10 @@ package com.lwise.util
 
 import com.lwise.listeners.messages.MessageListener
 import com.lwise.listeners.reactions.ReactionListener
+import com.lwise.types.toMessageEvent
 import com.lwise.types.toReactionAddEvent
 import com.lwise.types.toReactionRemoveEvent
 import discord4j.core.GatewayDiscordClient
-import discord4j.core.`object`.entity.Message
 import discord4j.core.event.domain.lifecycle.ReadyEvent
 import discord4j.core.event.domain.message.MessageCreateEvent
 import discord4j.core.event.domain.message.ReactionAddEvent
@@ -23,18 +23,17 @@ fun GatewayDiscordClient.subscribeToReady() {
 fun GatewayDiscordClient.subscribeToMessages(listeners: List<MessageListener>) {
     var listener: MessageListener? = null
     eventDispatcher.on(MessageCreateEvent::class.java)
-        .map { it.message }
-        .filter { message ->
+        .filter { event ->
             // don't respond to messages from other bots
-            message.author.map { !it.isBot }.orElse(false)
+            event.message.author.map { !it.isBot }.orElse(false)
         }
-        .filter { message ->
-            listener = listeners.firstOrNull { it.isTriggered(message.content) }
+        .filter { event ->
+            listener = listeners.firstOrNull { it.isTriggered(event.message.content) }
             listener != null
         }
-        .flatMap(Message::getChannel)
-        .flatMap { channel ->
-            listener?.respond(channel)
+        .map(MessageCreateEvent::toMessageEvent)
+        .flatMap {
+            listener?.respond(it)
         }
         .subscribe()
 }

--- a/src/test/kotlin/ReactionListenerTest.kt
+++ b/src/test/kotlin/ReactionListenerTest.kt
@@ -9,7 +9,7 @@ class ReactionListenerTest {
     fun `test AlignmentListener triggers`() {
         val alignmentListener = AlignmentReactionListener()
         val meowBot = MockMeowBot(listOf(alignmentListener))
-        AlignmentDefinitions.EMOJI_NAME_LIST.forEach {
+        AlignmentDefinitions.EMOJI_NAMES.forEach {
             Assert.assertEquals(true, meowBot.firesOnReaction(it))
         }
         Assert.assertEquals(false, meowBot.firesOnReaction("some_other_custom_emoji"))


### PR DESCRIPTION
When someone posts `m!play alignment`, the bot will add them into the user database (if they are not there already) and give them the "True Neutral" role to start with.

I also refactored `MessageListener` to take in the entire `MessageEvent` so that more complex things can be done if triggered by a message.

Resolves #19