### PR TITLE
Have MeowBot sync with database and update alignment roles according to points

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation "com.discord4j:discord4j-core:3.1.1"
     implementation "ch.qos.logback:logback-classic:1.2.3"
     implementation 'org.postgresql:postgresql:42.2.10'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.0-M1'
 
     testImplementation("junit:junit:4.13")
 }

--- a/src/main/kotlin/com/lwise/MeowBot.kt
+++ b/src/main/kotlin/com/lwise/MeowBot.kt
@@ -31,12 +31,12 @@ fun main() {
     val messageListeners = listOf(MeowListener(), AlignmentOptInListener())
     val reactionListeners = listOf(AlignmentReactionListener())
     client?.apply {
-        launchDatabaseSyncRoutine(30000)
         subscribeToReady()
         subscribeToMessages(messageListeners)
         subscribeToReactionAdds(reactionListeners)
         subscribeToReactionRemoves(reactionListeners)
         subscribeToDatabaseSync()
+        launchDatabaseSyncRoutine(300000) // 5 minutes
         onDisconnect().block()
     }
 }

--- a/src/main/kotlin/com/lwise/MeowBot.kt
+++ b/src/main/kotlin/com/lwise/MeowBot.kt
@@ -5,7 +5,9 @@ import com.lwise.listeners.messages.MeowListener
 import com.lwise.listeners.reactions.AlignmentReactionListener
 import com.lwise.util.DatabaseClient
 import com.lwise.util.TableTransformer
+import com.lwise.util.launchDatabaseSyncRoutine
 import com.lwise.util.log
+import com.lwise.util.subscribeToDatabaseSync
 import com.lwise.util.subscribeToMessages
 import com.lwise.util.subscribeToReactionAdds
 import com.lwise.util.subscribeToReactionRemoves
@@ -29,10 +31,12 @@ fun main() {
     val messageListeners = listOf(MeowListener(), AlignmentOptInListener())
     val reactionListeners = listOf(AlignmentReactionListener())
     client?.apply {
+        launchDatabaseSyncRoutine(30000)
         subscribeToReady()
         subscribeToMessages(messageListeners)
         subscribeToReactionAdds(reactionListeners)
         subscribeToReactionRemoves(reactionListeners)
+        subscribeToDatabaseSync()
         onDisconnect().block()
     }
 }

--- a/src/main/kotlin/com/lwise/alignment/AlignmentDefinitions.kt
+++ b/src/main/kotlin/com/lwise/alignment/AlignmentDefinitions.kt
@@ -1,18 +1,40 @@
 package com.lwise.alignment
 
+import com.lwise.util.log
+
 class AlignmentDefinitions {
     companion object {
         val EMOJI_NAMES = listOf("lawful", "chaotic", "good", "evil")
-        val ALIGNMENT_ROLES = listOf(
-            "Chaotic Evil",
-            "Chaotic Good",
-            "Chaotic Neutral",
-            "True Neutral",
-            "Lawful Neutral",
-            "Lawful Good",
-            "Lawful Evil",
-            "Neutral Good",
-            "Neutral Evil"
+        val ALIGNMENT_ROLES = mapOf<String, String>(
+            Pair("Chaotic Evil", "769426100178386965"),
+            Pair("Chaotic Good", "769425366526853130"),
+            Pair("Chaotic Neutral", "769424331037999104"),
+            Pair("True Neutral", "769424037201444944"),
+            Pair("Lawful Neutral", "769424130629959691"),
+            Pair("Lawful Good", "769424575116083230"),
+            Pair("Lawful Evil", "769425124755505183"),
+            Pair("Neutral Good", "769611488868433930"),
+            Pair("Neutral Evil", "769611569465786429")
         )
+        private const val ARBITRARY_ALIGNMENT_THRESHOLD = 3
+
+        fun calculateRole(chaotic: Int, lawful: Int, good: Int, evil: Int): String {
+            val goodnessPoints = good - evil
+            val lawfulnessPoints = lawful - chaotic
+            val goodness = when {
+                goodnessPoints > ARBITRARY_ALIGNMENT_THRESHOLD -> "Good"
+                (goodnessPoints * -1) > ARBITRARY_ALIGNMENT_THRESHOLD -> "Evil"
+                else -> "Neutral"
+            }
+            val lawfulNess = when {
+                lawfulnessPoints > ARBITRARY_ALIGNMENT_THRESHOLD -> "Lawful"
+                (lawfulnessPoints * -1) > ARBITRARY_ALIGNMENT_THRESHOLD -> "Chaotic"
+                else -> "Neutral"
+            }
+            val roleName = "$lawfulNess $goodness"
+            log(this::class.java.name, "role: $roleName")
+            if (roleName == "Neutral Neutral") return "True Neutral"
+            return roleName
+        }
     }
 }

--- a/src/main/kotlin/com/lwise/alignment/AlignmentDefinitions.kt
+++ b/src/main/kotlin/com/lwise/alignment/AlignmentDefinitions.kt
@@ -5,7 +5,7 @@ import com.lwise.util.log
 class AlignmentDefinitions {
     companion object {
         val EMOJI_NAMES = listOf("lawful", "chaotic", "good", "evil")
-        val ALIGNMENT_ROLES = mapOf<String, String>(
+        val ALIGNMENT_ROLES = mapOf(
             Pair("Chaotic Evil", "769426100178386965"),
             Pair("Chaotic Good", "769425366526853130"),
             Pair("Chaotic Neutral", "769424331037999104"),
@@ -16,7 +16,7 @@ class AlignmentDefinitions {
             Pair("Neutral Good", "769611488868433930"),
             Pair("Neutral Evil", "769611569465786429")
         )
-        private const val ARBITRARY_ALIGNMENT_THRESHOLD = 3
+        private const val ARBITRARY_ALIGNMENT_THRESHOLD = 20
 
         fun calculateRole(chaotic: Int, lawful: Int, good: Int, evil: Int): String {
             val goodnessPoints = good - evil
@@ -26,12 +26,12 @@ class AlignmentDefinitions {
                 (goodnessPoints * -1) > ARBITRARY_ALIGNMENT_THRESHOLD -> "Evil"
                 else -> "Neutral"
             }
-            val lawfulNess = when {
+            val lawfulness = when {
                 lawfulnessPoints > ARBITRARY_ALIGNMENT_THRESHOLD -> "Lawful"
                 (lawfulnessPoints * -1) > ARBITRARY_ALIGNMENT_THRESHOLD -> "Chaotic"
                 else -> "Neutral"
             }
-            val roleName = "$lawfulNess $goodness"
+            val roleName = "$lawfulness $goodness"
             log(this::class.java.name, "role: $roleName")
             if (roleName == "Neutral Neutral") return "True Neutral"
             return roleName

--- a/src/main/kotlin/com/lwise/listeners/messages/AlignmentOptInListener.kt
+++ b/src/main/kotlin/com/lwise/listeners/messages/AlignmentOptInListener.kt
@@ -1,7 +1,7 @@
 package com.lwise.listeners.messages
 
 import com.lwise.alignment.AlignmentDefinitions.Companion.ALIGNMENT_ROLES
-import com.lwise.types.MessageEvent
+import com.lwise.types.events.MessageEvent
 import com.lwise.util.DatabaseClient
 import discord4j.common.util.Snowflake
 import discord4j.core.`object`.entity.Message
@@ -24,7 +24,7 @@ class AlignmentOptInListener : MessageListener {
             .map { role ->
                 role.name
             }.filter { roleName ->
-                ALIGNMENT_ROLES.contains(roleName)
+                ALIGNMENT_ROLES.keys.contains(roleName)
             }.collectList()
         val filteredRoles = userAlignmentRoles.block()!!
         return if (!filteredRoles.isNullOrEmpty()) {

--- a/src/main/kotlin/com/lwise/listeners/messages/MessageListener.kt
+++ b/src/main/kotlin/com/lwise/listeners/messages/MessageListener.kt
@@ -1,7 +1,7 @@
 package com.lwise.listeners.messages
 
 import com.lwise.listeners.Listener
-import com.lwise.types.MessageEvent
+import com.lwise.types.events.MessageEvent
 import discord4j.core.`object`.entity.Message
 import reactor.core.publisher.Mono
 

--- a/src/main/kotlin/com/lwise/listeners/reactions/AlignmentReactionListener.kt
+++ b/src/main/kotlin/com/lwise/listeners/reactions/AlignmentReactionListener.kt
@@ -1,9 +1,9 @@
 package com.lwise.listeners.reactions
 
 import com.lwise.alignment.AlignmentDefinitions.Companion.EMOJI_NAMES
-import com.lwise.types.ReactionEvent
-import com.lwise.types.ReactionEventType
 import com.lwise.types.UserData
+import com.lwise.types.events.ReactionEvent
+import com.lwise.types.events.ReactionEventType
 import com.lwise.util.DatabaseClient
 import com.lwise.util.UserDataTransformer
 import discord4j.core.`object`.entity.Message

--- a/src/main/kotlin/com/lwise/listeners/reactions/ReactionListener.kt
+++ b/src/main/kotlin/com/lwise/listeners/reactions/ReactionListener.kt
@@ -1,7 +1,7 @@
 package com.lwise.listeners.reactions
 
 import com.lwise.listeners.Listener
-import com.lwise.types.ReactionEvent
+import com.lwise.types.events.ReactionEvent
 import discord4j.core.`object`.entity.Message
 import reactor.core.publisher.Mono
 

--- a/src/main/kotlin/com/lwise/types/DatabaseSyncEvent.kt
+++ b/src/main/kotlin/com/lwise/types/DatabaseSyncEvent.kt
@@ -1,0 +1,18 @@
+package com.lwise.types
+
+import discord4j.common.util.Snowflake
+import discord4j.core.GatewayDiscordClient
+import discord4j.core.`object`.entity.Guild
+import discord4j.core.event.domain.Event
+import discord4j.gateway.ShardInfo
+import reactor.core.publisher.Mono
+
+class DatabaseSyncEvent(
+    private val gateway: GatewayDiscordClient,
+    shardInfo: ShardInfo,
+    private val guildId: Snowflake,
+    private val users: List<UserData>
+) : Event(gateway, shardInfo) {
+    fun getGuild(): Mono<Guild> { return gateway.getGuildById(guildId) }
+    fun getUsers(): List<UserData> { return users }
+}

--- a/src/main/kotlin/com/lwise/types/events/EventTypes.kt
+++ b/src/main/kotlin/com/lwise/types/events/EventTypes.kt
@@ -1,4 +1,4 @@
-package com.lwise.types
+package com.lwise.types.events
 
 import discord4j.core.`object`.entity.Guild
 import discord4j.core.`object`.entity.Member

--- a/src/main/kotlin/com/lwise/util/CoroutineExtensions.kt
+++ b/src/main/kotlin/com/lwise/util/CoroutineExtensions.kt
@@ -1,0 +1,19 @@
+package com.lwise.util
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+
+fun CoroutineScope.launchPeriodicAsync(
+    repeatMillis: Long,
+    action: () -> Unit
+) = this.async {
+    if (repeatMillis > 0) {
+        while (true) {
+            action()
+            delay(repeatMillis)
+        }
+    } else {
+        action()
+    }
+}

--- a/src/main/kotlin/com/lwise/util/UserDataListTransformer.kt
+++ b/src/main/kotlin/com/lwise/util/UserDataListTransformer.kt
@@ -1,0 +1,23 @@
+package com.lwise.util
+
+import com.lwise.types.UserData
+import java.sql.ResultSet
+
+class UserDataListTransformer : ResultTransformer<List<UserData>> {
+    override fun transform(resultSet: ResultSet): List<UserData> {
+        val userList = mutableListOf<UserData>()
+        while (resultSet.next()) {
+            userList.add(
+                UserData(
+                    id = resultSet.getLong("id"),
+                    userName = resultSet.getString("username"),
+                    chaoticPoints = resultSet.getInt("chaotic_points"),
+                    lawfulPoints = resultSet.getInt("lawful_points"),
+                    goodPoints = resultSet.getInt("good_points"),
+                    evilPoints = resultSet.getInt("evil_points")
+                )
+            )
+        }
+        return userList
+    }
+}


### PR DESCRIPTION
- Added Kotlin coroutines: we launch a periodic coroutine to sync with the database
- When the database syncs it emits a `DatabaseSyncEvent` (which has hardcoded guildId... hahaha technical debt)
- The MeowBot subscribes to `DatabaseSyncEvents`... when it gets one it checks the `users` table, calculate's each user's alignment score, and if needed, updates each user's alignment role accordingly

Resolves #15 