### PR TITLE
Fix meowbot crash

### DIFF
--- a/src/main/kotlin/com/lwise/listeners/messages/MessageListener.kt
+++ b/src/main/kotlin/com/lwise/listeners/messages/MessageListener.kt
@@ -15,7 +15,10 @@ interface MessageListener : Listener<MessageEvent> {
     }
 
     override fun respond(responseVector: MessageEvent): Mono<Message> {
-        return responseVector.channel.createMessage(getResponseMessage())
+        getResponseMessage().takeIf { it.isNotEmpty() }?.let {
+            return responseVector.channel.createMessage(it)
+        }
+        return Mono.empty()
     }
 
     fun getResponseMessage(): String

--- a/src/main/kotlin/com/lwise/util/CatFactClient.kt
+++ b/src/main/kotlin/com/lwise/util/CatFactClient.kt
@@ -10,8 +10,9 @@ object CatFactClient {
     private var client = OkHttpClient()
     private val url = HttpUrl.Builder()
         .scheme("https")
-        .host("catfact.ninja")
-        .addPathSegment("fact")
+        .host("cat-fact.herokuapp.com")
+        .addPathSegment("facts")
+        .addQueryParameter("amount", "1")
         .build()
 
     fun getCatFact(): String? {
@@ -23,7 +24,7 @@ object CatFactClient {
             val response = client.newCall(request).execute()
             val result = JSONObject(response.body!!.string())
             log(this::class.java.name, result.toString())
-            return result.get("fact").toString()
+            return result.getJSONArray("all").getJSONObject(0).get("text").toString()
         } catch (exception: IOException) {
             logException(this::class.java.name, "Cannot retrieve fact from $queryFactUrl", exception)
             return null


### PR DESCRIPTION
- Don't allow meowbot to send an empty message
- Use a different cat facts api

Resolves #46