### PR TITLE
Add basic music playing functionality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@ version '0.0.1'
 repositories {
     jcenter()
     mavenCentral()
+    maven {
+        url 'https://m2.dv8tion.net/releases'
+    }
 }
 
 compileKotlin {
@@ -54,6 +57,7 @@ dependencies {
     implementation 'org.postgresql:postgresql:42.2.10'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.0-M1'
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
+    implementation 'com.sedmelluq:lavaplayer:1.3.78'
     compile 'org.json:json:20190722'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'

--- a/src/main/kotlin/com/lwise/MeowBot.kt
+++ b/src/main/kotlin/com/lwise/MeowBot.kt
@@ -4,9 +4,12 @@ import com.lwise.listeners.messages.AdviceListener
 import com.lwise.listeners.messages.AlignmentOptInListener
 import com.lwise.listeners.messages.CatPictureListener
 import com.lwise.listeners.messages.MeowListener
+import com.lwise.listeners.messages.QueueSongListener
+import com.lwise.listeners.messages.VoiceJoinListener
 import com.lwise.listeners.reactions.AlignmentReactionListener
 import com.lwise.listeners.reactions.FishReactionListener
 import com.lwise.util.launchDatabaseSyncRoutine
+import com.lwise.util.player.MusicPlayer
 import com.lwise.util.subscribeToDatabaseSync
 import com.lwise.util.subscribeToMessages
 import com.lwise.util.subscribeToReactionAdds
@@ -19,12 +22,17 @@ fun main() {
     val dotenv = dotenv {
         ignoreIfMissing = true
     }
+
+    // This initializes the MusicPlayer; objects are weird
+    // This init needs to happen before the client initializes (according to the library creator)
+    MusicPlayer
+
     val client = DiscordClientBuilder.create(dotenv["BOT_TOKEN"] ?: System.getenv("BOT_TOKEN"))
         .build()
         .login()
         .block()
 
-    val messageListeners = listOf(MeowListener(), AlignmentOptInListener(), CatPictureListener(), AdviceListener())
+    val messageListeners = listOf(MeowListener(), AlignmentOptInListener(), CatPictureListener(), AdviceListener(), VoiceJoinListener(), QueueSongListener())
     val reactionListeners = listOf(AlignmentReactionListener(), FishReactionListener())
     client?.apply {
         subscribeToReady()

--- a/src/main/kotlin/com/lwise/listeners/messages/QueueSongListener.kt
+++ b/src/main/kotlin/com/lwise/listeners/messages/QueueSongListener.kt
@@ -1,0 +1,19 @@
+package com.lwise.listeners.messages
+
+import com.lwise.types.events.MessageEvent
+import com.lwise.util.player.MusicPlayer
+import discord4j.core.`object`.entity.Message
+import reactor.core.publisher.Mono
+
+class QueueSongListener : MessageListener {
+    override val regexString: String
+        get() = "m!queue\\s.*"
+
+    override fun getResponseMessage(): String = ""
+
+    override fun respond(responseVector: MessageEvent): Mono<Message> {
+        val url = responseVector.message.content.split(" ")[1]
+        MusicPlayer.addTrackToQueue(url)
+        return Mono.empty()
+    }
+}

--- a/src/main/kotlin/com/lwise/listeners/messages/VoiceJoinListener.kt
+++ b/src/main/kotlin/com/lwise/listeners/messages/VoiceJoinListener.kt
@@ -1,0 +1,25 @@
+package com.lwise.listeners.messages
+
+import com.lwise.types.events.MessageEvent
+import com.lwise.util.player.MusicPlayer
+import discord4j.core.`object`.entity.Message
+import reactor.core.publisher.Mono
+
+class VoiceJoinListener : MessageListener {
+    override val regexString: String
+        get() = "m!join"
+
+    override fun getResponseMessage(): String = ""
+
+    override fun respond(responseVector: MessageEvent): Mono<Message> {
+        val requestingUser = responseVector.author
+        requestingUser?.let { user ->
+            user.voiceState.block()?.let { voiceState ->
+                voiceState.channel.block()?.join { spec ->
+                    spec.setProvider(MusicPlayer.audioProvider)
+                }?.block()
+            }
+        }
+        return Mono.empty()
+    }
+}

--- a/src/main/kotlin/com/lwise/util/player/LavaPlayerAudioProvider.kt
+++ b/src/main/kotlin/com/lwise/util/player/LavaPlayerAudioProvider.kt
@@ -1,0 +1,27 @@
+package com.lwise.util.player
+
+import com.sedmelluq.discord.lavaplayer.format.StandardAudioDataFormats
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
+import com.sedmelluq.discord.lavaplayer.track.playback.MutableAudioFrame
+import discord4j.voice.AudioProvider
+import java.nio.ByteBuffer
+
+class LavaPlayerAudioProvider(private val player: AudioPlayer) : AudioProvider(
+    ByteBuffer.allocate(
+        StandardAudioDataFormats.DISCORD_OPUS.maximumChunkSize()
+    )
+) {
+    private val frame: MutableAudioFrame = MutableAudioFrame()
+
+    init {
+        frame.setBuffer(buffer)
+    }
+
+    override fun provide(): Boolean {
+        // AudioPlayer writes audio data to its AudioFrame
+        val didProvide = player.provide(frame)
+        // If audio was provided, flip from write mode to read mode
+        if (didProvide) buffer.flip()
+        return didProvide
+    }
+}

--- a/src/main/kotlin/com/lwise/util/player/MusicPlayer.kt
+++ b/src/main/kotlin/com/lwise/util/player/MusicPlayer.kt
@@ -1,0 +1,58 @@
+package com.lwise.util.player
+
+import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager
+import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager
+import com.sedmelluq.discord.lavaplayer.source.AudioSourceManagers
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException
+import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import com.sedmelluq.discord.lavaplayer.track.playback.NonAllocatingAudioFrameBuffer
+import discord4j.voice.AudioProvider
+
+object MusicPlayer {
+    private val player: AudioPlayer
+    private val playerManager: AudioPlayerManager
+    private val trackScheduler: TrackScheduler
+    val audioProvider: AudioProvider
+
+    init {
+        playerManager = DefaultAudioPlayerManager()
+        playerManager.configuration.setFrameBufferFactory(::NonAllocatingAudioFrameBuffer)
+        AudioSourceManagers.registerRemoteSources(playerManager)
+        AudioSourceManagers.registerLocalSource(playerManager)
+        player = playerManager.createPlayer()
+        audioProvider = LavaPlayerAudioProvider(player)
+        trackScheduler = TrackScheduler(player)
+        player.addListener(trackScheduler)
+    }
+
+    fun addTrackToQueue(url: String) {
+        playerManager.loadItemOrdered(this, url, ResultHandler())
+    }
+
+    private fun play(track: AudioTrack) {
+        trackScheduler.queue(track)
+    }
+
+    class ResultHandler : AudioLoadResultHandler {
+        override fun trackLoaded(track: AudioTrack?) {
+            track?.let { play(it) }
+        }
+
+        override fun playlistLoaded(playlist: AudioPlaylist?) {
+            playlist?.tracks?.forEach { track ->
+                play(track)
+            }
+        }
+
+        override fun noMatches() {
+            // MeowBot can handle this later
+        }
+
+        override fun loadFailed(exception: FriendlyException?) {
+            // MeowBot can handle this later
+        }
+    }
+}

--- a/src/main/kotlin/com/lwise/util/player/TrackScheduler.kt
+++ b/src/main/kotlin/com/lwise/util/player/TrackScheduler.kt
@@ -1,0 +1,34 @@
+package com.lwise.util.player
+
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
+import com.sedmelluq.discord.lavaplayer.player.event.AudioEventAdapter
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
+
+class TrackScheduler(private val player: AudioPlayer) : AudioEventAdapter() {
+    private val queue: BlockingQueue<AudioTrack>
+
+    init {
+        queue = LinkedBlockingQueue()
+    }
+
+    fun queue(track: AudioTrack) {
+        if (!player.startTrack(track, true)) {
+            queue.offer(track)
+        }
+    }
+
+    private fun nextTrack() {
+        player.startTrack(queue.poll(), false)
+    }
+
+    override fun onTrackEnd(player: AudioPlayer?, track: AudioTrack?, endReason: AudioTrackEndReason?) {
+        endReason?.let {
+            if (it.mayStartNext) {
+                nextTrack()
+            }
+        }
+    }
+}


### PR DESCRIPTION
So here we use the library [LavaPlayer](https://github.com/sedmelluq/lavaplayer) to play urls through Discord Voice.

We add listeners for the `m!queue <url>` command - which adds music to the `MusicPlayer`'s queue, and for the `m!join` command, which lets MeowBot join the current user's voice channel (if it can see it of course).

The `LavaPlayerProvider` class does some stuff that apparently optimizes for playing over Discord. It still doesn't sound great 🤷‍♀️ 

`MusicPlayer` is kind of the interface with interacting with the `TrackScheduler` which holds the actual queue.