### PR TITLE
Add ability to check the current music queue

### DIFF
--- a/src/main/kotlin/com/lwise/MeowBot.kt
+++ b/src/main/kotlin/com/lwise/MeowBot.kt
@@ -5,6 +5,7 @@ import com.lwise.listeners.messages.AlignmentOptInListener
 import com.lwise.listeners.messages.CatPictureListener
 import com.lwise.listeners.messages.MeowListener
 import com.lwise.listeners.messages.QueueSongListener
+import com.lwise.listeners.messages.ShowQueueListener
 import com.lwise.listeners.messages.VoiceJoinListener
 import com.lwise.listeners.reactions.AlignmentReactionListener
 import com.lwise.listeners.reactions.FishReactionListener
@@ -32,7 +33,7 @@ fun main() {
         .login()
         .block()
 
-    val messageListeners = listOf(MeowListener(), AlignmentOptInListener(), CatPictureListener(), AdviceListener(), VoiceJoinListener(), QueueSongListener())
+    val messageListeners = listOf(MeowListener(), AlignmentOptInListener(), CatPictureListener(), AdviceListener(), VoiceJoinListener(), QueueSongListener(), ShowQueueListener())
     val reactionListeners = listOf(AlignmentReactionListener(), FishReactionListener())
     client?.apply {
         subscribeToReady()

--- a/src/main/kotlin/com/lwise/listeners/messages/ShowQueueListener.kt
+++ b/src/main/kotlin/com/lwise/listeners/messages/ShowQueueListener.kt
@@ -1,0 +1,42 @@
+package com.lwise.listeners.messages
+
+import com.lwise.types.events.MessageEvent
+import com.lwise.util.ConfigUtil
+import com.lwise.util.player.MusicPlayer
+import discord4j.core.`object`.entity.Message
+import discord4j.core.spec.EmbedCreateSpec
+import discord4j.rest.util.Color
+import reactor.core.publisher.Mono
+import java.util.function.Consumer
+
+class ShowQueueListener : MessageListener {
+    companion object {
+        private const val MAX_SONG_DISPLAY_SIZE = 10
+    }
+
+    override val regexString: String
+        get() = "m!queue"
+
+    override fun getResponseMessage(): String = ""
+
+    override fun respond(responseVector: MessageEvent): Mono<Message> {
+        val nowPlayingString = MusicPlayer.getNowPlayingAsString()
+        if (MusicPlayer.isEmpty && nowPlayingString.isNullOrEmpty()) {
+            return responseVector.channel.createMessage("You need to queue some songs first! /ᐠ. ⱉ .ᐟ\\\\ﾉ Use `m!queue <url>`")
+        }
+        // Can add paging functionality later
+        val queueListString = MusicPlayer.getQueueDataAsStringList(0, MAX_SONG_DISPLAY_SIZE).joinToString("\n")
+        val consumer = Consumer<EmbedCreateSpec> { embedSpec ->
+            embedSpec.apply {
+                setColor(Color.DARK_GOLDENROD)
+                setTitle("Music Queue ${ConfigUtil.emoji["happyCat"]}")
+                nowPlayingString?.let {
+                    addField("Now Playing", it, false)
+                }
+                setDescription(queueListString)
+            }
+        }
+
+        return responseVector.channel.createEmbed(consumer)
+    }
+}

--- a/src/main/kotlin/com/lwise/util/CollectionUtil.kt
+++ b/src/main/kotlin/com/lwise/util/CollectionUtil.kt
@@ -1,0 +1,4 @@
+package com.lwise.util
+
+fun <T> List<T>.safeSubList(fromIndex: Int, toIndex: Int): List<T> =
+    this.subList(fromIndex.coerceAtLeast(0), toIndex.coerceAtMost(this.size))

--- a/src/main/kotlin/com/lwise/util/player/MusicPlayer.kt
+++ b/src/main/kotlin/com/lwise/util/player/MusicPlayer.kt
@@ -1,5 +1,6 @@
 package com.lwise.util.player
 
+import com.lwise.util.safeSubList
 import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager
@@ -16,6 +17,8 @@ object MusicPlayer {
     private val playerManager: AudioPlayerManager
     private val trackScheduler: TrackScheduler
     val audioProvider: AudioProvider
+    val isEmpty: Boolean
+        get() = trackScheduler.isEmpty
 
     init {
         playerManager = DefaultAudioPlayerManager()
@@ -30,6 +33,24 @@ object MusicPlayer {
 
     fun addTrackToQueue(url: String) {
         playerManager.loadItemOrdered(this, url, ResultHandler())
+    }
+
+    fun getQueueDataAsStringList(fromIndex: Int, toIndex: Int): List<String> {
+        return trackScheduler.getQueueTrackList().safeSubList(fromIndex, toIndex).mapIndexed { index, track ->
+            track.toStringWithIndex(index)
+        }
+    }
+
+    fun getNowPlayingAsString(): String? {
+        return player.playingTrack?.toDescriptionString()
+    }
+
+    private fun AudioTrack.toStringWithIndex(index: Int): String {
+        return "${index + 1}. ${toDescriptionString()}"
+    }
+
+    private fun AudioTrack.toDescriptionString(): String {
+        return info.title
     }
 
     private fun play(track: AudioTrack) {

--- a/src/main/kotlin/com/lwise/util/player/TrackScheduler.kt
+++ b/src/main/kotlin/com/lwise/util/player/TrackScheduler.kt
@@ -9,6 +9,8 @@ import java.util.concurrent.LinkedBlockingQueue
 
 class TrackScheduler(private val player: AudioPlayer) : AudioEventAdapter() {
     private val queue: BlockingQueue<AudioTrack>
+    val isEmpty: Boolean
+        get() = queue.isEmpty()
 
     init {
         queue = LinkedBlockingQueue()
@@ -18,6 +20,10 @@ class TrackScheduler(private val player: AudioPlayer) : AudioEventAdapter() {
         if (!player.startTrack(track, true)) {
             queue.offer(track)
         }
+    }
+
+    fun getQueueTrackList(): List<AudioTrack> {
+        return queue.toList()
     }
 
     private fun nextTrack() {


### PR DESCRIPTION
Adds functionality to show the current queue (and now playing) as an embed discord message with `m!queue` (no arguments).

<img width="393" alt="Screen Shot 2021-11-20 at 11 59 01 PM" src="https://user-images.githubusercontent.com/13436240/142750188-5584f4f1-ab5a-4014-af9e-33c78c9f41ae.png">
