### PR TITLE
Add pause, play, and skip commands for Meowbot music

### DIFF
--- a/src/main/kotlin/com/lwise/ListenerRegistry.kt
+++ b/src/main/kotlin/com/lwise/ListenerRegistry.kt
@@ -1,0 +1,40 @@
+package com.lwise
+
+import com.lwise.listeners.messages.AdviceListener
+import com.lwise.listeners.messages.AlignmentOptInListener
+import com.lwise.listeners.messages.CatPictureListener
+import com.lwise.listeners.messages.ClearQueueListener
+import com.lwise.listeners.messages.MeowListener
+import com.lwise.listeners.messages.PauseMusicListener
+import com.lwise.listeners.messages.QueueSongListener
+import com.lwise.listeners.messages.RemoveFromQueueListener
+import com.lwise.listeners.messages.ResumeMusicListener
+import com.lwise.listeners.messages.SecretSantaListener
+import com.lwise.listeners.messages.ShowQueueListener
+import com.lwise.listeners.messages.SkipSongListener
+import com.lwise.listeners.messages.VoiceJoinListener
+import com.lwise.listeners.reactions.AlignmentReactionListener
+import com.lwise.listeners.reactions.FishReactionListener
+
+object ListenerRegistry {
+    val messageListeners = listOf(
+        MeowListener(),
+        AlignmentOptInListener(),
+        CatPictureListener(),
+        AdviceListener(),
+        SecretSantaListener(),
+        VoiceJoinListener(),
+        QueueSongListener(),
+        ShowQueueListener(),
+        RemoveFromQueueListener(),
+        ClearQueueListener(),
+        PauseMusicListener(),
+        ResumeMusicListener(),
+        SkipSongListener()
+    )
+
+    val reactionListeners = listOf(
+        AlignmentReactionListener(),
+        FishReactionListener()
+    )
+}

--- a/src/main/kotlin/com/lwise/MeowBot.kt
+++ b/src/main/kotlin/com/lwise/MeowBot.kt
@@ -1,15 +1,7 @@
 package com.lwise
 
-import com.lwise.listeners.messages.AdviceListener
-import com.lwise.listeners.messages.AlignmentOptInListener
-import com.lwise.listeners.messages.CatPictureListener
-import com.lwise.listeners.messages.ClearQueueListener
-import com.lwise.listeners.messages.MeowListener
-import com.lwise.listeners.messages.RemoveFromQueueListener
-import com.lwise.listeners.messages.SecretSantaListener
-import com.lwise.listeners.messages.ShowQueueListener
-import com.lwise.listeners.reactions.AlignmentReactionListener
-import com.lwise.listeners.reactions.FishReactionListener
+import com.lwise.ListenerRegistry.messageListeners
+import com.lwise.ListenerRegistry.reactionListeners
 import com.lwise.util.launchDatabaseSyncRoutine
 import com.lwise.util.player.MusicPlayer
 import com.lwise.util.subscribeToDatabaseSync
@@ -34,18 +26,6 @@ fun main() {
         .login()
         .block()
 
-    val messageListeners = listOf(
-        MeowListener(),
-        AlignmentOptInListener(),
-        CatPictureListener(),
-        AdviceListener(),
-        SecretSantaListener(),
-        ShowQueueListener(),
-        RemoveFromQueueListener(),
-        ClearQueueListener()
-    )
-
-    val reactionListeners = listOf(AlignmentReactionListener(), FishReactionListener())
     client?.apply {
         subscribeToReady()
         subscribeToMessages(messageListeners)

--- a/src/main/kotlin/com/lwise/listeners/messages/PauseMusicListener.kt
+++ b/src/main/kotlin/com/lwise/listeners/messages/PauseMusicListener.kt
@@ -1,0 +1,18 @@
+package com.lwise.listeners.messages
+
+import com.lwise.types.events.MessageEvent
+import com.lwise.util.player.MusicPlayer
+import discord4j.core.`object`.entity.Message
+import reactor.core.publisher.Mono
+
+class PauseMusicListener : MessageListener {
+    override val regexString: String
+        get() = "m!pause"
+
+    override fun getResponseMessage(): String = ""
+
+    override fun respond(responseVector: MessageEvent): Mono<Message> {
+        MusicPlayer.pause()
+        return super.respond(responseVector)
+    }
+}

--- a/src/main/kotlin/com/lwise/listeners/messages/ResumeMusicListener.kt
+++ b/src/main/kotlin/com/lwise/listeners/messages/ResumeMusicListener.kt
@@ -1,0 +1,18 @@
+package com.lwise.listeners.messages
+
+import com.lwise.types.events.MessageEvent
+import com.lwise.util.player.MusicPlayer
+import discord4j.core.`object`.entity.Message
+import reactor.core.publisher.Mono
+
+class ResumeMusicListener : MessageListener {
+    override val regexString: String
+        get() = "m!play"
+
+    override fun getResponseMessage(): String = ""
+
+    override fun respond(responseVector: MessageEvent): Mono<Message> {
+        MusicPlayer.resume()
+        return super.respond(responseVector)
+    }
+}

--- a/src/main/kotlin/com/lwise/listeners/messages/SkipSongListener.kt
+++ b/src/main/kotlin/com/lwise/listeners/messages/SkipSongListener.kt
@@ -1,0 +1,18 @@
+package com.lwise.listeners.messages
+
+import com.lwise.types.events.MessageEvent
+import com.lwise.util.player.MusicPlayer
+import discord4j.core.`object`.entity.Message
+import reactor.core.publisher.Mono
+
+class SkipSongListener : MessageListener {
+    override val regexString: String
+        get() = "m!skip"
+
+    override fun getResponseMessage(): String = ""
+
+    override fun respond(responseVector: MessageEvent): Mono<Message> {
+        MusicPlayer.skip()
+        return super.respond(responseVector)
+    }
+}

--- a/src/main/kotlin/com/lwise/util/player/MusicPlayer.kt
+++ b/src/main/kotlin/com/lwise/util/player/MusicPlayer.kt
@@ -53,6 +53,18 @@ object MusicPlayer {
         trackScheduler.clearQueue()
     }
 
+    fun pause() {
+        player.isPaused = true
+    }
+
+    fun resume() {
+        player.isPaused = false
+    }
+
+    fun skip() {
+        trackScheduler.nextTrack()
+    }
+
     private fun AudioTrack.toStringWithIndex(index: Int): String {
         return "${index + 1}. ${toDescriptionString()}"
     }

--- a/src/main/kotlin/com/lwise/util/player/TrackScheduler.kt
+++ b/src/main/kotlin/com/lwise/util/player/TrackScheduler.kt
@@ -41,7 +41,7 @@ class TrackScheduler(private val player: AudioPlayer) : AudioEventAdapter() {
         queue.clear()
     }
 
-    private fun nextTrack() {
+    fun nextTrack() {
         player.startTrack(queue.poll(), false)
     }
 


### PR DESCRIPTION
Also re-instates the listeners that got accidentally deleted.

`m!pause` pauses the music
`m!play` resumes the music
`m!skip` skips the currently playing song

Resolves https://github.com/lwise/meowbot/issues/64
Resolves https://github.com/lwise/meowbot/issues/61

