### PR TITLE
Configure Fixie for Meowbot Lavaplayer requests

### DIFF
--- a/src/main/kotlin/com/lwise/clients/FixieClient.kt
+++ b/src/main/kotlin/com/lwise/clients/FixieClient.kt
@@ -1,0 +1,47 @@
+package com.lwise.clients
+
+import io.github.cdimascio.dotenv.dotenv
+import okhttp3.Authenticator
+import okhttp3.Credentials
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import org.apache.http.HttpHost
+import org.apache.http.auth.AuthScope
+import org.apache.http.auth.UsernamePasswordCredentials
+import org.apache.http.impl.client.BasicCredentialsProvider
+import java.net.URL
+
+// We are using Fixie to give Meowbot a static IP so that it isn't constantly banned from Youtube
+// https://devcenter.heroku.com/articles/fixie
+
+object FixieClient {
+    val dotenv = dotenv {
+        ignoreIfMissing = true
+    }
+
+    val fixieUser: String
+    val fixiePassword: String
+    val credentialsProvider: BasicCredentialsProvider
+    val proxyHost: HttpHost
+
+    init {
+        val fixieUrlString: String = dotenv["FIXIE_URL"] ?: System.getenv("FIXIE_URL")
+        val fixieUrl = URL(fixieUrlString)
+        fixieUser = fixieUrl.userInfo.split(":")[0]
+        fixiePassword = fixieUrl.userInfo.split(":")[1]
+        val fixieHost = fixieUrl.host
+        val fixiePort = fixieUrl.port
+        credentialsProvider = BasicCredentialsProvider().apply {
+            setCredentials(AuthScope(fixieHost, fixiePort), UsernamePasswordCredentials(fixieUser, fixiePassword))
+        }
+        proxyHost = HttpHost(fixieHost, fixiePort)
+    }
+
+    class ProxyAuthenticator : Authenticator {
+        override fun authenticate(route: Route?, response: Response): Request {
+            val credential = Credentials.basic(fixieUser, fixiePassword)
+            return response.request.newBuilder().header("Proxy-Authorization", credential).build()
+        }
+    }
+}

--- a/src/main/kotlin/com/lwise/player/MusicPlayer.kt
+++ b/src/main/kotlin/com/lwise/player/MusicPlayer.kt
@@ -1,5 +1,6 @@
 package com.lwise.player
 
+import com.lwise.clients.FixieClient
 import com.lwise.util.ConfigUtil
 import com.lwise.util.safeSubList
 import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler
@@ -13,6 +14,7 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import com.sedmelluq.discord.lavaplayer.track.playback.NonAllocatingAudioFrameBuffer
 import discord4j.core.`object`.entity.channel.MessageChannel
 import discord4j.voice.AudioProvider
+import org.apache.http.client.config.RequestConfig
 
 object MusicPlayer {
     private val player: AudioPlayer
@@ -25,6 +27,14 @@ object MusicPlayer {
     init {
         playerManager = DefaultAudioPlayerManager()
         playerManager.configuration.setFrameBufferFactory(::NonAllocatingAudioFrameBuffer)
+        playerManager.setHttpRequestConfigurator { config ->
+            RequestConfig.copy(config)
+                .setProxy(FixieClient.proxyHost)
+                .build()
+        }
+        playerManager.setHttpBuilderConfigurator { config ->
+            config.setProxy(FixieClient.proxyHost).setDefaultCredentialsProvider(FixieClient.credentialsProvider).build()
+        }
         AudioSourceManagers.registerRemoteSources(playerManager)
         AudioSourceManagers.registerLocalSource(playerManager)
         player = playerManager.createPlayer()


### PR DESCRIPTION
I hope this works?

Introduces `FIXIE_URL` environment variable which we can pass the details of to `LavaPlayer` `AudioProvider` which will hopefully use these details to send YT requests through Fixie and therefore not through a banned IP address??????