### PR TITLE
Swap out lavaplayer library for a more updated fork

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,8 @@ version '0.0.1'
 
 repositories {
     mavenCentral()
-    maven {
-        url 'https://m2.dv8tion.net/releases'
-    }
+    maven { url 'https://m2.dv8tion.net/releases' }
+    maven { url 'https://jitpack.io' }
 }
 
 compileKotlin {
@@ -56,7 +55,7 @@ dependencies {
     implementation 'org.postgresql:postgresql:42.3.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2-native-mt'
     implementation 'com.squareup.okhttp3:okhttp:4.9.2'
-    implementation 'com.sedmelluq:lavaplayer:1.3.78'
+    implementation 'com.github.walkyst:lavaplayer-fork:1.3.97'
     implementation 'se.michaelthelin.spotify:spotify-web-api-java:7.0.0'
     compile 'org.json:json:20210307'
 


### PR DESCRIPTION
It seems like lavaplayer hasn't been updated for about a year, so we are switching to a more maintained fork: https://github.com/Walkyst/lavaplayer-fork

At least for now 🤷‍♀️ 